### PR TITLE
feat:#22_メインページ作成

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,14 @@
     <% unless controller_name == 'sessions' && action_name == 'new' %>
       <%= render "shared/header" %>
     <% end %>
-    <%= yield %>
+
+    <main>
+      <%= yield %>
+    </main>
+
+    <% unless controller_path.start_with?("devise/") %>
+      <%= render "shared/footer" %>
+    <% end %>
+
   </body>
 </html>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -2,11 +2,33 @@
 <% content_for(:show_back_button, false) %>
 
 
-<h1>メインページ</h1>
-<p>ログイン済みユーザーのみ見られます</p>
+<div class="max-w-md mx-auto px-4 py-4 space-y-4">
 
-<%= image_tag "icons/cleaning.png" %>
+  <!-- 検索欄（仮） -->
+  <div class="flex items-center space-x-2">
+    <input type="text" placeholder="投稿の検索" class="flex-1 border rounded-lg px-3 py-2 text-sm" />
+    <button class="px-4 py-2 text-sm bg-gray-200 rounded-lg">検索</button>
 
-<%= form_with url: "#", method: :get do |f| %>
-  <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "カテゴリを選択…" %>
-<% end %>
+    <%= form_with url: "#", method: :get do |f| %>
+      <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "カテゴリを選択…" %>
+    <% end %>
+  </div>
+
+  <!-- 投稿一覧（まだ仮） -->
+  <div id="posts-list" class="space-y-4">
+    <!-- 投稿カード(仮) -->
+    <div class="bg-gray-100 rounded-lg p-4 text-gray-500 text-sm">
+      投稿がまだありません
+    </div>
+  </div>
+
+</div>
+
+<!-- 右下の追加ボタン -->
+<button
+  class="fixed bottom-20 right-6 w-14 h-14 bg-pink-300 text-white rounded-full shadow-lg flex items-center justify-center text-3xl">
+  +
+</button>
+
+
+

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,48 @@
+<footer class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 z-50">
+  <nav class="flex justify-around py-2 text-xs text-gray-600">
+    
+    <!-- ホーム -->
+    <%= link_to "#", class: "flex flex-col items-center" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l9-9 9 9M4.5 10.5v9a1.5 1.5 0 001.5 1.5h3m6 0h3a1.5 1.5 0 001.5-1.5v-9" />
+      </svg>
+      <span>ホーム</span>
+    <% end %>
+
+
+    <!-- 通知 -->
+    <%= link_to "#", class: "flex flex-col items-center" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+      </svg>
+      <span>通知</span>
+    <% end %>
+
+
+    <!-- 伝言板 -->
+    <%= link_to "#", class: "flex flex-col items-center" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3h9m-9 3h6M4.5 6.75v10.5a1.5 1.5 0 001.5 1.5h12a1.5 1.5 0 001.5-1.5V6.75a1.5 1.5 0 00-1.5-1.5h-12a1.5 1.5 0 00-1.5 1.5z" />
+      </svg>
+      <span>伝言板</span>
+    <% end %>
+
+
+    <!-- お役立ち -->
+    <%= link_to "#", class: "flex flex-col items-center" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
+      </svg>
+      <span>お役立ち</span>
+    <% end %>
+
+    <!-- マイページ -->
+    <%= link_to "#", class: "flex flex-col items-center" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25a8.25 8.25 0 1115 0" />
+      </svg>
+      <span>マイページ</span>
+    <% end %>
+
+  </nav>
+</footer>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -33,3 +33,4 @@
 <% end %>
 
 <%= render "users/shared/links" %>
+


### PR DESCRIPTION
# 概要
- メインページに投稿一覧用の枠を追加  
- フッターを作成  
- ヘッダー・フッターを画面ごとに表示/非表示で切り替える分岐を実装

# 変更内容
- 投稿一覧のコンテナを追加  
- フッターのデザインと配置を作成  
- `render` 条件を追加し、ログイン関連ページではヘッダー/フッターを非表示に設定

# 備考
- デザイン調整は別PRで対応予定

close #22
close #23
