### PR TITLE
style:ログイン・新規登録ページのデザイン修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,29 @@
 @import "tailwindcss";
+
+@theme {
+  --color-forest-green: #707C57;
+  --color-sage: #B3B792;
+  --color-wood-dark: #725C3A;
+  --color-accent-orange: #DA983C;
+  --color-wood-light: #C39F78;
+  --color-cream: #E5D2B8;
+  --color-earth-brown: #90533B;
+}
+
+@layer components {
+  .btn {
+    @apply inline-flex items-center justify-center
+           rounded-lg px-6 py-2 text-sm font-medium
+           transition focus:outline-none;
+  }
+
+  .btn-primary {
+    @apply bg-accent-orange text-white
+           hover:bg-wood-dark;
+  }
+
+  .btn-secondary {
+    @apply bg-sage text-wood-dark
+           hover:bg-forest-green hover:text-white;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,8 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
+    
+
   </head>
 
   <body>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -3,31 +3,40 @@
 <% content_for(:back_path, main_path) %>
 
 
-<div class="max-w-md mx-auto px-4 py-4 space-y-4">
+<div class="max-w-md mx-auto px-4 py-4 space-y-6 bg-cream min-h-screen">
+<div class="bg-cream text-forest-green p-4">
+  Tailwind v4 テスト
+</div>
+
 
   <% if @partner.nil? %>
-    <p>まだペアが設定されていません。</p>
+    <p class="text-sm text-wood-dark">
+      まだペアが設定されていません。
+    </p>
   <% else %>
-    <div>
-      あなた: <%= current_user.name || "名無し" %> | 
+    <div class="text-xs text-wood-dark">
+      あなた: <%= current_user.name || "名無し" %> /
       相手: <%= @partner.name || "名無し" %>
     </div>
   <% end %>
 
   <!-- 検索欄（仮） -->
   <div class="flex items-center space-x-2">
-    <input type="text" placeholder="投稿の検索（工事中）" class="flex-1 border rounded-lg px-3 py-2 text-sm" />
-    <button class="px-4 py-2 text-sm bg-gray-200 rounded-lg">検索</button>
-
-    <%= form_with url: "#", method: :get do |f| %>
-      <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "カテゴリを選択…" %>
-    <% end %>
+    <input
+      type="text"
+      placeholder="投稿の検索（工事中）"
+      class="flex-1 rounded-lg px-3 py-2 text-sm bg-white shadow-sm"
+    />
+    <button class="px-4 py-2 text-sm bg-sage text-wood-dark rounded-lg">
+      検索
+    </button>
   </div>
 
   <!-- 投稿一覧 -->
-  <div id="posts-list" class="space-y-4">
-    <% if @posts.any? %> <!-- 1件以上あるか？ -->
-      <h2 class="text-sm font-semibold text-gray-500 mb-2">
+  <div id="posts-list" class="space-y-6">
+    <% if @posts.any? %>
+
+      <h2 class="text-xs font-semibold text-wood-dark">
         最近の大事な投稿
       </h2>
 
@@ -38,28 +47,27 @@
               last_viewed_at: @last_viewed_at %>
         <% end %>
       <% else %>
-        <div class="text-sm text-gray-400 px-2">
-          なし
-        </div>
+        <p class="text-xs text-wood-light px-2">なし</p>
       <% end %>
 
-
-      <h2 class="text-sm font-semibold text-gray-500 mb-2">
+      <h2 class="text-xs font-semibold text-wood-dark mt-6">
         通常投稿
-     </h2>
+      </h2>
+
       <% @other_posts.each do |post| %>
         <%= render "posts/post_card",
             post: post,
             last_viewed_at: @last_viewed_at %>
       <% end %>
+
     <% else %>
-      <div class="bg-gray-100 rounded-lg p-4 text-gray-500 text-sm">
+      <div class="bg-white rounded-xl p-6 text-wood-light text-sm shadow-sm">
         投稿がまだありません
       </div>
     <% end %>
   </div>
-
 </div>
+
 
 <!-- 右下の追加ボタン -->
 <%= link_to new_post_path,

--- a/app/views/posts/_post_card.html.erb
+++ b/app/views/posts/_post_card.html.erb
@@ -1,41 +1,60 @@
 <% bg_class =
   case post.sense_level
-  when "high" then "bg-red-200"
-  when "medium" then "bg-yellow-200"
-  when "low" then "bg-green-200"
-  else "bg-gray-100"
+  when "high" then "bg-wood-light"
+  when "medium" then "bg-cream"
+  when "low" then "bg-sage"
+  else "bg-white"
   end %>
 
 <%= link_to post_path(post), class: "block" do %>
-  <div class="<%= bg_class %> flex rounded-lg shadow p-4 h-32 mb-4">
+  <div
+    class="
+      <%= bg_class %>
+      flex
+      rounded-xl
+      shadow-md
+      p-4
+      mb-6
+      transform rotate-1 hover:rotate-0
+      transition-transform
+    "
+  >
     <!-- 左側 カテゴリアイコンと優先度 -->
     <div class="flex-shrink-0 mr-4 flex flex-col items-center justify-center w-16 space-y-2">
       <% if post.category&.icon.present? %>
         <%= image_tag(post.category.icon, alt: post.category.name, class: "w-8 h-8") %>
       <% end %>
-      <div class="text-center text-xs text-gray-400">
+      <div class="text-center text-xs text-wood-dark">
         優先度: <%= post.sense_level_jp %>
       </div>
     </div>
 
+    <!-- 右側 -->
+    <div class="flex flex-col flex-grow">
 
-    <!-- 右側 カテゴリ、タイトル、答え合わせまでの時間 -->
-    <div class="flex flex-col flex-grow h-full">
       <!-- 答え公開時の演出 -->
       <% if post.just_unlocked?(last_viewed_at) %>
-        <div class="text-xs text-blue-500 mb-1">
+        <div class="text-xs text-accent-orange mb-1">
           🔓 答えが公開されました
         </div>
       <% end %>
 
-      <p class="text-sm text-gray-500 mb-1">
+      <p class="text-xs text-wood-dark mb-1">
         カテゴリ: <%= post.category.name %>
       </p>
 
-      <h3 class="text-lg font-semibold mb-2 <%= 'text-blue-600' if post.user != current_user && Time.current < post.reveal_at %>">
+      <h3
+        class="
+          text-base
+          font-semibold
+          mb-2
+          text-forest-green
+          <%= 'text-accent-orange' if post.user != current_user && Time.current < post.reveal_at %>
+        "
+      >
         <%= post.title_for_view(current_user) %>
         <% if last_viewed_at.nil? || post.created_at > last_viewed_at %>
-          <span class="ml-2 text-xs bg-pink-300 text-white px-2 py-0.5 rounded-full">
+          <span class="ml-2 text-xs bg-accent-orange text-white px-2 py-0.5 rounded-full">
             New
           </span>
         <% end %>
@@ -44,21 +63,23 @@
       <% if post.reveal_at.present? && Time.current < post.reveal_at %>
         <div class="mt-auto text-xs">
           <% hours_left = ((post.reveal_at - Time.current) / 1.hour).ceil %>
-          <span class="<%= 'text-red-500 font-semibold' if hours_left <= 1 %>">
+          <span class="<%= 'text-red-600 font-semibold' if hours_left <= 1 %> text-wood-dark">
             答え合わせまであと <%= hours_left %>時間！
           </span>
         </div>
       <% end %>
 
-      <!-- 下側 投稿者、アイコン、投稿日 -->
-      <div class="flex items-center justify-end mt-auto text-xs text-gray-400 space-x-2">
+      <!-- 下側 投稿者情報 -->
+      <div class="flex items-center justify-end mt-auto text-xs text-wood-dark space-x-2">
         <% if post.user.icon.present? %>
           <%= image_tag("user_icons/#{post.user.icon}", class: "w-6 h-6 rounded-full") %>
         <% end %>
         <span><%= post.user.name %></span>
-        <span><%= post.created_at.in_time_zone.strftime("%Y/%m/%d %H:%M") %>
-</span>
+        <span>
+          <%= post.created_at.in_time_zone.strftime("%Y/%m/%d %H:%M") %>
+        </span>
       </div>
+
     </div>
   </div>
 <% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,50 +1,87 @@
 <% content_for(:page_title, t('users.registrations.new.sign_up')) %>
 <% content_for(:show_back_button, true) %>
 
-<h2>ここはユーザー登録画面！</h2>
+<div class="max-w-md mx-auto px-4 py-8">
+  <div class="bg-white rounded-xl shadow-sm p-6 space-y-6">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+    <h2 class="text-xl font-semibold text-forest-green text-center">
+      ユーザー登録
+    </h2>
 
-  <div class="field">
-    <%= f.label :email, t('.email') %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource,
+          as: resource_name,
+          url: registration_path(resource_name),
+          data: { turbo: false },
+          html: { class: "space-y-4" }) do |f| %>
+
+      <%= render "users/shared/error_messages", resource: resource %>
+
+      <!-- メールアドレス -->
+      <div>
+        <%= f.label :email, t('.email'),
+              class: "block text-sm text-wood-dark mb-1" %>
+        <%= f.email_field :email,
+              autofocus: true,
+              autocomplete: "email",
+              class: "w-full rounded-lg border border-wood-light px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sage" %>
+      </div>
+
+      <!-- パスワード -->
+      <div>
+        <%= f.label :password, t('.password'),
+              class: "block text-sm text-wood-dark mb-1" %>
+        <% if @minimum_password_length %>
+          <p class="text-xs text-gray-500 mb-1">
+            <%= @minimum_password_length %>文字以上
+          </p>
+        <% end %>
+        <%= f.password_field :password,
+              autocomplete: "new-password",
+              class: "w-full rounded-lg border border-wood-light px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sage" %>
+      </div>
+
+      <!-- パスワード確認 -->
+      <div>
+        <%= f.label :password_confirmation, t('.password_confirmation'),
+              class: "block text-sm text-wood-dark mb-1" %>
+        <%= f.password_field :password_confirmation,
+              autocomplete: "new-password",
+              class: "w-full rounded-lg border border-wood-light px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sage" %>
+      </div>
+
+      <!-- 名前 -->
+      <div>
+        <%= f.label :name, t('.name'),
+              class: "block text-sm text-wood-dark mb-1" %>
+        <%= f.text_field :name,
+              class: "w-full rounded-lg border border-wood-light px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sage" %>
+      </div>
+
+      <!-- 性別 -->
+      <div>
+        <%= f.label :sex, t('.sex'),
+              class: "block text-sm text-wood-dark mb-1" %>
+        <%= f.select :sex,
+              [["男性", "man"], ["女性", "woman"], ["その他", "other"]],
+              { include_blank: "選択してください" },
+              class: "w-full rounded-lg border border-wood-light px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-sage",
+              required: true %>
+      </div>
+
+      <!-- アイコン選択 -->
+      <%= render "shared/icon_select", f: f %>
+
+      <!-- 登録ボタン -->
+      <div class="pt-2">
+        <%= f.submit t('.sign_up'),
+              class: "w-full bg-accent-orange text-white py-3 rounded-lg font-semibold hover:bg-wood-dark transition" %>
+      </div>
+
+    <% end %>
+
+    <div class="text-center text-sm text-gray-500">
+      <%= render "users/shared/links" %>
+    </div>
+
   </div>
-
-  <div class="field">
-    <%= f.label :password, t('.password') %>
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, t('.password_confirmation') %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <!-- 追加カラム -->
-  <div class="field">
-    <%= f.label :name, t('.name') %><br>
-    <%= f.text_field :name %>
-  </div>
-
-  <div class="field">
-  <%= f.label :sex, t('.sex') %><br>
-  <%= f.select :sex,
-        [["男性", "man"], ["女性", "woman"], ["その他", "other"]],
-        { include_blank: "選択してください" },
-        { required: true } %>
 </div>
-
-
-  <%= render "shared/icon_select", f: f %>
-
-
-  <div class="actions">
-    <%= f.submit t('.sign_up') %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,45 +1,58 @@
 <% content_for(:page_title, t('users.sessions.new.sign_in')) %>
 <% content_for(:show_back_button, true) %>
 
-<% if flash[:alert] %>
-  <div class="text-red-500 mb-4" data-turbo-cache="false">
-    <%= flash[:alert] %>
-  </div>
-<% end %>
+<div class="min-h-[70vh] flex items-center justify-center px-4">
+  <div class="w-full max-w-md bg-white rounded-xl shadow p-6 space-y-6">
 
+    <% if flash[:alert] %>
+      <div class="bg-red-100 text-red-600 text-sm rounded-lg px-4 py-2" data-turbo-cache="false">
+        <%= flash[:alert] %>
+      </div>
+    <% end %>
 
-<h2 class="text-2xl font-bold mb-4">ここはログイン画面！</h2>
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email, t('.email') %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <h2 class="text-xl font-semibold text-center text-wood-dark">
+      ログイン
+    </h2>
 
-  <div class="field">
-    <%= f.label :password, t('.password') %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="space-y-4">
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me, t('.remember_me') %>
+        <div>
+          <%= f.label :email, t('.email'), class: "block text-sm text-gray-600 mb-1" %>
+          <%= f.email_field :email,
+                autofocus: true,
+                autocomplete: "email",
+                class: "w-full border rounded-lg px-3 py-2 text-sm" %>
+        </div>
+
+        <div>
+          <%= f.label :password, t('.password'), class: "block text-sm text-gray-600 mb-1" %>
+          <%= f.password_field :password,
+                autocomplete: "current-password",
+                class: "w-full border rounded-lg px-3 py-2 text-sm" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="flex items-center text-sm text-gray-600">
+            <%= f.check_box :remember_me, class: "mr-2" %>
+            <%= f.label :remember_me, t('.remember_me') %>
+          </div>
+        <% end %>
+
+        <%= f.submit t('.sign_in'), class: "btn btn-primary w-full" %>
+      </div>
+    <% end %>
+
+    <div class="text-sm text-center text-gray-500">
+      <%= render "users/shared/links" %>
     </div>
-  <% end %>
 
-  <div class="actions">
-    <%= f.submit t('.sign_in') %>
+    <div class="pt-4 border-t text-center">
+      <%= button_to "デモで使ってみる",
+            demo_login_path,
+            method: :post,
+            class: "btn btn-secondary w-full" %>
+    </div>
+
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
-
-
-<div class="mt-6 text-center">
-  <%= button_to "デモで使ってみる",
-        demo_login_path,
-        method: :post,
-        class: "btn btn-secondary" %>
 </div>
-
-

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to t('.log_in'), new_session_path(resource_name) %><br />
+  <%= link_to "ログインページへ", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>


### PR DESCRIPTION
## 概要
ログイン／新規登録画面のデザインを調整しました。

## 変更内容
- Tailwind CSS v4（CSS First）でテーマカラーを定義
- ログイン画面のレイアウトを整理
- 新規登録画面をログイン画面と同じレイアウトに統一
- Devise共通リンクの文言を調整（「ログイン」→「ログインページへ」）

## 補足
フォーム系画面のデザイン統一の土台づくりを目的としています。

Refs #63 